### PR TITLE
Remove CoreRegistry usage.

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "AlterationEffects",
-    "version" : "0.1.1-SNAPSHOT",
+    "version" : "0.2.0-SNAPSHOT",
     "author" : "Marcin Sciesinski <marcins78@gmail.com>",
     "displayName" : "AlterationEffects",
     "description" : "Allows for applying modifying effects to a player (or something else) that alters their base state in some fashion.",

--- a/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
@@ -17,11 +17,18 @@ package org.terasology.alterationEffects.breath;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
-import org.terasology.registry.CoreRegistry;
 
 public class WaterBreathingAlterationEffect implements AlterationEffect {
+
+    private DelayManager delayManager;
+
+    public WaterBreathingAlterationEffect(Context context) {
+        delayManager = context.get(DelayManager.class);
+    }
+
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
         final WaterBreathingComponent component = entity.getComponent(WaterBreathingComponent.class);
@@ -29,6 +36,6 @@ public class WaterBreathingAlterationEffect implements AlterationEffect {
             entity.saveComponent(new WaterBreathingComponent());
         }
 
-        CoreRegistry.get(DelayManager.class).addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING, duration);
+        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING, duration);
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
@@ -17,27 +17,36 @@ package org.terasology.alterationEffects.regenerate;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.context.Context;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.math.TeraMath;
-import org.terasology.registry.CoreRegistry;
 
 public class RegenerationAlterationEffect implements AlterationEffect {
+
+    private final Time time;
+    private final DelayManager delayManager;
+
+    public RegenerationAlterationEffect(Context context) {
+        this.time = context.get(Time.class);
+        this.delayManager = context.get(DelayManager.class);
+    }
+
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
         RegenerationComponent regeneration = entity.getComponent(RegenerationComponent.class);
         if (regeneration == null) {
             regeneration = new RegenerationComponent();
             regeneration.regenerationAmount = TeraMath.floorToInt(magnitude);
-            regeneration.lastRegenerationTime = CoreRegistry.get(Time.class).getGameTimeInMs();
+            regeneration.lastRegenerationTime = time.getGameTimeInMs();
             entity.addComponent(regeneration);
         } else {
             regeneration.regenerationAmount = TeraMath.floorToInt(magnitude);
-            regeneration.lastRegenerationTime = CoreRegistry.get(Time.class).getGameTimeInMs();
+            regeneration.lastRegenerationTime = time.getGameTimeInMs();
             entity.addComponent(regeneration);
         }
 
-        CoreRegistry.get(DelayManager.class).addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION, duration);
+        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION, duration);
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
@@ -17,11 +17,18 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
-import org.terasology.registry.CoreRegistry;
 
 public class SwimSpeedAlterationEffect implements AlterationEffect {
+
+    private final DelayManager delayManager;
+
+    public SwimSpeedAlterationEffect(Context context) {
+        this.delayManager = context.get(DelayManager.class);
+    }
+
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
         boolean add = false;
@@ -38,6 +45,6 @@ public class SwimSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(swimSpeed);
         }
 
-        CoreRegistry.get(DelayManager.class).addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
+        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
@@ -17,11 +17,18 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
-import org.terasology.registry.CoreRegistry;
 
 public class WalkSpeedAlterationEffect implements AlterationEffect {
+
+    private DelayManager delayManager;
+
+    public WalkSpeedAlterationEffect(Context context) {
+        this.delayManager = context.get(DelayManager.class);
+    }
+
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
         boolean add = false;
@@ -38,6 +45,6 @@ public class WalkSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(walkSpeed);
         }
 
-        CoreRegistry.get(DelayManager.class).addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
+        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
     }
 }


### PR DESCRIPTION
Reasoning: Coregistry usage is deprecated and a bad pattern.

Requires  Terasology/WoodAndStone#38
