### PR TITLE
Added DURATION_INDEFINITE

### DIFF
--- a/src/main/java/org/terasology/alterationEffects/AlterationEffects.java
+++ b/src/main/java/org/terasology/alterationEffects/AlterationEffects.java
@@ -16,6 +16,7 @@
 package org.terasology.alterationEffects;
 
 public final class AlterationEffects {
+    public static final int DURATION_INDEFINITE = -1;
     public static final String EXPIRE_TRIGGER_PREFIX = "AlterationEffects:Expire:";
 
     public static final String WALK_SPEED = "WalkSpeed";

--- a/src/main/java/org/terasology/alterationEffects/boost/HealthBoostAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/boost/HealthBoostAlterationEffect.java
@@ -43,7 +43,7 @@ public class HealthBoostAlterationEffect implements AlterationEffect {
             hbot.lastUseTime = time.getGameTimeInMs();
 
             HealthComponent h = entity.getComponent(HealthComponent.class);
-            h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f*hbot.boostAmount));
+            h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f * hbot.boostAmount));
 
             entity.addComponent(hbot);
         } else {
@@ -54,12 +54,14 @@ public class HealthBoostAlterationEffect implements AlterationEffect {
 
             hbot.boostAmount = TeraMath.floorToInt(magnitude);
             hbot.lastUseTime = time.getGameTimeInMs();
-            h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f*hbot.boostAmount));
+            h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f * hbot.boostAmount));
 
             entity.addComponent(hbot);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MAX_HEALTH_BOOST, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MAX_HEALTH_BOOST, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
@@ -36,7 +36,9 @@ public class WaterBreathingAlterationEffect implements AlterationEffect {
             entity.saveComponent(new WaterBreathingComponent());
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/damageOverTime/DamageOverTimeAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/damageOverTime/DamageOverTimeAlterationEffect.java
@@ -65,6 +65,8 @@ public class DamageOverTimeAlterationEffect implements AlterationEffect {
 
         entity.saveComponent(dot);
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DAMAGE_OVER_TIME + ":" + id, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DAMAGE_OVER_TIME + ":" + id, duration);
+        }
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
@@ -48,7 +48,9 @@ public class DecoverAlterationEffect implements AlterationEffect {
             entity.addComponent(decover);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DECOVER, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DECOVER, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
@@ -47,7 +47,9 @@ public class RegenerationAlterationEffect implements AlterationEffect {
             entity.addComponent(regeneration);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/resist/ResistDamageAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/resist/ResistDamageAlterationEffect.java
@@ -63,6 +63,8 @@ public class ResistDamageAlterationEffect implements AlterationEffect {
 
         entity.saveComponent(dot);
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.RESIST_DAMAGE + ":" + id, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.RESIST_DAMAGE + ":" + id, duration);
+        }
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
@@ -45,7 +45,9 @@ public class GlueAlterationEffect implements AlterationEffect {
             entity.saveComponent(glue);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
@@ -47,8 +47,9 @@ public class ItemUseSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(jumpSpeed);
         }
 
-        delayManager.addDelayedAction(entity,
-                AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity,AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
@@ -47,8 +47,9 @@ public class JumpSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(jumpSpeed);
         }
 
-        delayManager.addDelayedAction(entity,
-                AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity,AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
@@ -47,8 +47,9 @@ public class MultiJumpAlterationEffect implements AlterationEffect {
             entity.saveComponent(multiJump);
         }
 
-        delayManager.addDelayedAction(entity,
-                AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity,AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
@@ -37,7 +37,9 @@ public class StunAlterationEffect implements AlterationEffect {
             entity.addComponent(stun);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
@@ -45,7 +45,9 @@ public class SwimSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(swimSpeed);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
@@ -45,7 +45,9 @@ public class WalkSpeedAlterationEffect implements AlterationEffect {
             entity.saveComponent(walkSpeed);
         }
 
-        delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
+        if (duration != AlterationEffects.DURATION_INDEFINITE) {
+            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
+        }
     }
 
     @Override


### PR DESCRIPTION
As mentioned in [Terasology/Equipment#18](https://github.com/Terasology/Equipment/pull/18), I've added a DURATION_INDEFINITE value under the main AlterationEffects class. 

Effects applied using this duration value will not trigger the expireEffect DelayedAction. Especially useful for equippable items! 🙂 

However, it seems there's no way of truly making sure that the effect stays on as another applyEffect would override the indefinite duration.