### PR TITLE
draft: ComponentBasedAlterationEffect and implementations

### DIFF
--- a/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
@@ -42,7 +42,6 @@ public abstract class ComponentBasedAlterationEffect<C extends Component> implem
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
         //TODO: why pass magnitude and duration here instead of using it in the event
         entity.upsertComponent(componentClass, maybeComponent -> upsertComponent(maybeComponent, magnitude, duration));
-        C component = entity.getComponent(componentClass);
 
         // 2. send OnEffectModifyEvent
         OnEffectModifyEvent effectModifyEvent = entity.send(
@@ -57,7 +56,7 @@ public abstract class ComponentBasedAlterationEffect<C extends Component> implem
             modifiedDuration = effectModifyEvent.getShortestDuration();
 
             if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                component = updateComponent(effectModifyEvent, component);
+                entity.updateComponent(componentClass, c -> updateComponent(effectModifyEvent, c));
                 modifiersFound = true;
             }
         }

--- a/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
@@ -1,0 +1,89 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.alterationEffects;
+
+import org.terasology.alterationEffects.speed.WalkSpeedComponent;
+import org.terasology.context.Context;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
+
+public abstract class ComponentBasedAlterationEffect<C extends Component> implements AlterationEffect {
+
+    private final DelayManager delayManager;
+    private final Class<C> componentClass;
+    private final String effectId;
+
+    //TODO: this could be
+    //  (Context, Class<C>, String, BiFunction<Optional<C>, EffectContext, C>, BiFunction<OnEffectModifyEvent, C, C>)
+    public ComponentBasedAlterationEffect(Context context, Class<C> componentClass, String effectIdentifier) {
+        this.delayManager = context.get(DelayManager.class);
+        this.componentClass = componentClass;
+        this.effectId = effectIdentifier;
+    }
+
+    //TODO: this could be a
+    //  BiFunction<Optional<C>, EffectContext, C>
+    protected abstract C upsertComponent(Optional<C> maybeComponent, float magnitude, long duration);
+
+    //TODO this could be a
+    //  BiFunction<OnEffectModifyEvent, C, C>
+    protected abstract C updateComponent(OnEffectModifyEvent event, C component);
+
+    @Override
+    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
+        applyEffect(instigator, entity, "", magnitude, duration);
+    }
+
+    @Override
+    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        //TODO: why pass magnitude and duration here instead of using it in the event
+        entity.upsertComponent(componentClass, maybeComponent -> upsertComponent(maybeComponent, magnitude, duration));
+        C component = entity.getComponent(componentClass);
+
+        // 2. send OnEffectModifyEvent
+        OnEffectModifyEvent effectModifyEvent = entity.send(
+                new OnEffectModifyEvent(instigator, entity, 0, 0, this, id)
+        );
+
+        long modifiedDuration = 0;
+        boolean modifiersFound = false;
+
+        // If the effect modify event is consumed, don't apply this walk speed effect.
+        if (!effectModifyEvent.isConsumed()) {
+            modifiedDuration = effectModifyEvent.getShortestDuration();
+
+            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
+                component = updateComponent(effectModifyEvent, component);
+                modifiersFound = true;
+            }
+        }
+
+        // 3. update component from OnEffectModifyEvent
+        //      (OnEffectModifyEvent, C) -> C
+        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
+
+            String effectIDWithShortestDuration = effectModifyEvent.getEffectIDWithShortestDuration();
+            delayManager.addDelayedAction(entity,
+                    AlterationEffects.EXPIRE_TRIGGER_PREFIX + effectId + "|" + effectIDWithShortestDuration,
+                    modifiedDuration);
+        } else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
+            // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify
+            // event was not consumed,
+            // add a delayed action to the DelayManager using the old system.
+            delayManager.addDelayedAction(entity,
+                    AlterationEffects.EXPIRE_TRIGGER_PREFIX + effectId, duration);
+        } else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
+            // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event
+            // have infinite
+            // duration, remove the component associated with this walk speed effect.
+            entity.removeComponent(WalkSpeedComponent.class);
+        }
+        // If this point is reached and none of the above if-clauses were met, that means there was at least one
+        // modifier
+        // collected in the event which has infinite duration.
+    }
+}

--- a/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
@@ -3,7 +3,6 @@
 
 package org.terasology.alterationEffects;
 
-import org.terasology.alterationEffects.speed.WalkSpeedComponent;
 import org.terasology.context.Context;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -79,7 +78,7 @@ public abstract class ComponentBasedAlterationEffect<C extends Component> implem
             // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event
             // have infinite
             // duration, remove the component associated with this walk speed effect.
-            entity.removeComponent(WalkSpeedComponent.class);
+            entity.removeComponent(componentClass);
         }
         // If this point is reached and none of the above if-clauses were met, that means there was at least one
         // modifier

--- a/src/main/java/org/terasology/alterationEffects/EffectContext.java
+++ b/src/main/java/org/terasology/alterationEffects/EffectContext.java
@@ -1,0 +1,25 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.alterationEffects;
+
+import org.terasology.entitySystem.entity.EntityRef;
+
+/**
+ * Immutable context for implementing alteration effects.
+ */
+public class EffectContext {
+    public final EntityRef instigator;
+    public final EntityRef entity;
+    public final String id;
+    public final float magnitude;
+    public final long duration;
+
+    public EffectContext(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        this.instigator = instigator;
+        this.entity = entity;
+        this.id = id;
+        this.magnitude = magnitude;
+        this.duration = duration;
+    }
+}

--- a/src/main/java/org/terasology/alterationEffects/boost/HealthBoostAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/boost/HealthBoostAlterationEffect.java
@@ -1,160 +1,77 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.boost;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.health.HealthComponent;
 import org.terasology.math.TeraMath;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the health boost effect, which boosts an entity's maximum health (based on the
  * magnitude) for a specified duration.
  */
-public class HealthBoostAlterationEffect implements AlterationEffect {
+public class HealthBoostAlterationEffect extends ComponentBasedAlterationEffect<HealthBoostComponent> implements AlterationEffect {
 
     private final Time time;
-    private final DelayManager delayManager;
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the time and DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public HealthBoostAlterationEffect(Context context) {
+        super(context, HealthBoostComponent.class, AlterationEffects.MAX_HEALTH_BOOST);
         this.time = context.get(Time.class);
-        this.delayManager = context.get(DelayManager.class);
     }
 
     /**
      * Removes the effect of the given health boost from the entity.
      *
-     * @param entity        The entity which has the health boost effect.
-     * @param hBoost        The health boost component.
+     * @param entity The entity which has the health boost effect.
+     * @param boost The health boost component.
      */
-    private void removeBoost(EntityRef entity, HealthBoostComponent hBoost) {
-        HealthComponent h = entity.getComponent(HealthComponent.class);
-
-        // Reverse the max health boosting effect by dividing the old boost amount.
-        h.maxHealth = Math.round(h.maxHealth / (1f + 0.01f*hBoost.boostAmount));
-
-        // If the current health is greater than the new max health, set the current health value to be the max health.
-        if (h.currentHealth > h.maxHealth) {
-            h.currentHealth = h.maxHealth;
-        }
+    private void removeBoost(EntityRef entity, HealthBoostComponent boost) {
+        entity.updateComponent(HealthComponent.class, health -> {
+            // Reverse the max health boosting effect by dividing the old boost amount.
+            health.maxHealth = Math.round(health.maxHealth / (1f + 0.01f * boost.boostAmount));
+            if (health.currentHealth > health.maxHealth) {
+                health.currentHealth = health.maxHealth;
+            }
+            return health;
+        });
     }
 
-    /**
-     * This will apply the health boost effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own health boost effect related modifiers.
-     *
-     * @param instigator    The entity who applied the health boost effect.
-     * @param entity        The entity that the health boost effect is being applied on.
-     * @param magnitude     The magnitude of the health boost effect.
-     * @param duration      The duration of the health boost effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a health boost component attached. If so, just update the boost
-        // amount. Otherwise, create a new one and attach it to the entity.
-        HealthBoostComponent hbot = entity.getComponent(HealthBoostComponent.class);
-        if (hbot == null) {
-            hbot = new HealthBoostComponent();
-            hbot.boostAmount = TeraMath.floorToInt(magnitude);
-            entity.addComponent(hbot);
-        } else {
-            // Remove the current health boost in place.
-            removeBoost(entity, hbot);
-            hbot.boostAmount = TeraMath.floorToInt(magnitude);
-        }
+    protected HealthBoostComponent upsertComponent(Optional<HealthBoostComponent> maybeComponent,
+                                                   EffectContext context) {
+        maybeComponent.ifPresent(c -> removeBoost(context.entity, c));
+        HealthBoostComponent component = maybeComponent.orElse(new HealthBoostComponent());
+        component.boostAmount = TeraMath.floorToInt(context.magnitude);
+        return component;
+    }
 
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // health boost effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this health boost effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's boost amount and the
-            // modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                hbot.boostAmount = (int) modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        hbot.lastUseTime = time.getGameTimeInMs();
+    @Override
+    protected HealthBoostComponent updateComponent(OnEffectModifyEvent event, HealthBoostComponent component,
+                                                   EffectContext context) {
+        component.boostAmount = TeraMath.floorToInt(event.getMagnitudeResultValue());
+        component.lastUseTime = time.getGameTimeInMs();
 
         // Get the health component of this entity, and increase its max health using the health boost multiplier.
-        HealthComponent h = entity.getComponent(HealthComponent.class);
-        h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f * hbot.boostAmount));
+        context.entity.updateComponent(HealthComponent.class, h -> {
+            h.maxHealth = Math.round(h.maxHealth * (1 + 0.01f * component.boostAmount));
+            return h;
+        });
 
-        // Save the component so the latest changes to it don't get lost when the game's exited.
-        entity.saveComponent(hbot);
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MAX_HEALTH_BOOST + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MAX_HEALTH_BOOST, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this health boost effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(HealthBoostComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
-    }
-
-    /**
-     * This will apply the health boost effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the health boost effect.
-     * @param entity        The entity that the health boost effect is being applied on.
-     * @param id            Inapplicable to the health boost effect.
-     * @param magnitude     The magnitude of the health boost effect.
-     * @param duration      The duration of the health boost effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.breath;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -40,12 +41,13 @@ public class WaterBreathingAlterationEffect extends ComponentBasedAlterationEffe
 
     @Override
     protected WaterBreathingComponent upsertComponent(Optional<WaterBreathingComponent> maybeComponent,
-                                                      float magnitude, long duration) {
+                                                      final EffectContext context) {
         return maybeComponent.orElse(new WaterBreathingComponent());
     }
 
     @Override
-    protected WaterBreathingComponent updateComponent(OnEffectModifyEvent event, WaterBreathingComponent component) {
+    protected WaterBreathingComponent updateComponent(OnEffectModifyEvent event, WaterBreathingComponent component,
+                                                      final EffectContext context) {
         return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/breath/WaterBreathingAlterationEffect.java
@@ -15,106 +15,37 @@
  */
 package org.terasology.alterationEffects.breath;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the water breathing effect, which allows an entity to breathe underwater for a
  * specified duration.
  */
-public class WaterBreathingAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class WaterBreathingAlterationEffect extends ComponentBasedAlterationEffect<WaterBreathingComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public WaterBreathingAlterationEffect(Context context) {
-        delayManager = context.get(DelayManager.class);
+        super(context, WaterBreathingComponent.class, AlterationEffects.WATER_BREATHING);
     }
 
-    /**
-     * This will apply the water breathing effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own water breathing effect related modifiers.
-     *
-     * @param instigator    The entity who applied the water breathing effect.
-     * @param entity        The entity that the water breathing effect is being applied on.
-     * @param magnitude     Inapplicable to the water breathing effect.
-     * @param duration      The duration of the water breathing effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a water breathing component attached. If not, create a new one
-        // and attach it to the entity.
-        WaterBreathingComponent waterBreathing = entity.getComponent(WaterBreathingComponent.class);
-        if (waterBreathing == null) {
-            waterBreathing = new WaterBreathingComponent();
-            entity.addComponent(waterBreathing);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // water breathing effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this water breathing effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WATER_BREATHING, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this water breathing effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(WaterBreathingComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected WaterBreathingComponent upsertComponent(Optional<WaterBreathingComponent> maybeComponent,
+                                                      float magnitude, long duration) {
+        return maybeComponent.orElse(new WaterBreathingComponent());
     }
 
-    /**
-     * This will apply the water breathing effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the damage over time effect.
-     * @param entity        The entity that the damage over time effect is being applied on.
-     * @param id            Inapplicable to the water breathing effect.
-     * @param magnitude     Inapplicable to the water breathing effect.
-     * @param duration      The duration of the health boost effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected WaterBreathingComponent updateComponent(OnEffectModifyEvent event, WaterBreathingComponent component) {
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/buff/BuffDamageAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/buff/BuffDamageAlterationEffect.java
@@ -1,143 +1,57 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.buff;
 
 import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
 import org.terasology.math.TeraMath;
 
-/**
- * This handles the application of the buff damage effect, which allows an entity to buff certain damage types
- * (based on the magnitude) for a specified duration.
- */
-public class BuffDamageAlterationEffect implements AlterationEffect {
+import java.util.Optional;
 
-    private final DelayManager delayManager;
+/**
+ * This handles the application of the buff damage effect, which allows an entity to buff certain damage types (based on
+ * the magnitude) for a specified duration.
+ */
+public class BuffDamageAlterationEffect extends ComponentBasedAlterationEffect<BuffDamageComponent> implements AlterationEffect {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public BuffDamageAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, BuffDamageComponent.class, AlterationEffects.BUFF_DAMAGE);
     }
 
-    /**
-     * This will apply the buff damage effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, String, float, long)}.
-     *
-     * @param instigator    The entity who applied the buff damage effect.
-     * @param entity        The entity that the buff damage effect is being applied on.
-     * @param magnitude     The magnitude of the buff damage effect.
-     * @param duration      The duration of the buff damage effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        applyEffect(instigator, entity, "Default", magnitude, duration);
-    }
-
-    /**
-     * This will apply the buff damage effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own buff damage effect related modifiers.
-     *
-     * @param instigator    The entity who applied the buff damage effect.
-     * @param entity        The entity that the buff damage effect is being applied on.
-     * @param id            The ID of this buff damage effect. This is used for determining what damage type to add
-     *                      this resistance to.
-     * @param magnitude     The magnitude of the buff damage effect.
-     * @param duration      The duration of the buff damage effect.
-     */
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        // First, determine if the entity already has a buff damage component attached. If not, create a new one and
-        // attach it to the entity.
-        BuffDamageComponent buffDamageComponent = entity.getComponent(BuffDamageComponent.class);
-        if (buffDamageComponent == null) {
-            buffDamageComponent = new BuffDamageComponent();
-            entity.addComponent(buffDamageComponent);
-        }
-
+    protected BuffDamageComponent upsertComponent(Optional<BuffDamageComponent> maybeComponent, EffectContext context) {
+        BuffDamageComponent buffDamageComponent = maybeComponent.orElse(new BuffDamageComponent());
         // Create a new BuffDamageEffect instance and assign the damage type and amount based on the ID and
         // magnitude respectively.
         BuffDamageEffect buffDamageEffect = new BuffDamageEffect();
-        buffDamageEffect.damageType = id;
-        buffDamageEffect.buffAmount = TeraMath.floorToInt(magnitude);
+        buffDamageEffect.damageType = context.id;
+        buffDamageEffect.buffAmount = TeraMath.floorToInt(context.magnitude);
 
-        // If the current damage type doesn't already exist, add the buffDamageEffect into the map directly. Otherwise,
-        // replace the older one.
-        if (buffDamageComponent.bdes.get(id) == null) {
-            buffDamageComponent.bdes.put(id, buffDamageEffect);
-        } else {
-            buffDamageComponent.bdes.replace(id, buffDamageEffect);
-        }
+        buffDamageComponent.bdes.put(context.id, buffDamageEffect);
+        return buffDamageComponent;
+    }
 
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // buff damage effect. The ID is also sent to distinguish it from other possible buff damage effects.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, id));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
+    @Override
+    protected BuffDamageComponent updateComponent(OnEffectModifyEvent event, BuffDamageComponent component,
+                                                  final EffectContext context) {
+        BuffDamageEffect buffDamageEffect = component.bdes.get(context.id);
+        buffDamageEffect.buffAmount = (int) event.getMagnitudeResultValue();
+        return component;
+    }
 
-        // If the effect modify event is consumed, don't apply this buff damage effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the
-            // modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                buffDamageEffect.buffAmount = (int) modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // Save the component so the latest changes to it don't get lost when the game's exited.
-        entity.saveComponent(buffDamageComponent);
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.BUFF_DAMAGE
-                    + ":" + id + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.BUFF_DAMAGE
-                    + ":" + id, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the buff effect from the buff damage component.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            buffDamageComponent.bdes.remove(id, buffDamageEffect);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    @Override
+    protected void removeComponent(EffectContext context) {
+        BuffDamageComponent buffDamageComponent = context.entity.getComponent(componentClass);
+        buffDamageComponent.bdes.remove(context.id);
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
@@ -15,107 +15,36 @@
  */
 package org.terasology.alterationEffects.decover;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the decover effect, which prevents an entity from healing for a specified duration.
  */
-public class DecoverAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class DecoverAlterationEffect extends ComponentBasedAlterationEffect<DecoverComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public DecoverAlterationEffect(Context context) {
-        delayManager = context.get(DelayManager.class);
+        super(context, DecoverComponent.class, AlterationEffects.DECOVER);
     }
 
-    /**
-     * This will apply the decover effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own decover effect related modifiers.
-     *
-     * @param instigator    The entity who applied the decover effect.
-     * @param entity        The entity that the decover effect is being applied on.
-     * @param magnitude     Inapplicable to the decover effect.
-     * @param duration      The duration of the decover effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a decover component attached. If not, create a new one and attach
-        // it to the entity.
-        DecoverComponent decover = entity.getComponent(DecoverComponent.class);
-        if (decover == null) {
-            decover = new DecoverComponent();
-            entity.addComponent(decover);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // decover effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this decover effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the shortest duration, and assign them to the modifiedDuration.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                modifiersFound = true;
-            }
-        }
-
-        // Save the component so the latest changes to it don't get lost when the game's exited.
-        entity.saveComponent(decover);
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DECOVER + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.DECOVER, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this decover effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(DecoverComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected DecoverComponent upsertComponent(Optional<DecoverComponent> maybeComponent, float magnitude,
+                                               long duration) {
+        return maybeComponent.orElse(new DecoverComponent());
     }
 
-    /**
-     * This will apply the decover effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the decover effect.
-     * @param entity        The entity that the decover effect is being applied on.
-     * @param id            Inapplicable to the decover effect.
-     * @param magnitude     Inapplicable to the decover effect.
-     * @param duration      The duration of the decover effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected DecoverComponent updateComponent(OnEffectModifyEvent event, DecoverComponent component) {
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/decover/DecoverAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.decover;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -38,13 +39,13 @@ public class DecoverAlterationEffect extends ComponentBasedAlterationEffect<Deco
     }
 
     @Override
-    protected DecoverComponent upsertComponent(Optional<DecoverComponent> maybeComponent, float magnitude,
-                                               long duration) {
+    protected DecoverComponent upsertComponent(Optional<DecoverComponent> maybeComponent, final EffectContext context) {
         return maybeComponent.orElse(new DecoverComponent());
     }
 
     @Override
-    protected DecoverComponent updateComponent(OnEffectModifyEvent event, DecoverComponent component) {
+    protected DecoverComponent updateComponent(OnEffectModifyEvent event, DecoverComponent component,
+                                               final EffectContext context) {
         return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.regenerate;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 import org.terasology.engine.Time;
@@ -46,16 +47,17 @@ public class RegenerationAlterationEffect extends ComponentBasedAlterationEffect
     }
 
     @Override
-    protected RegenerationComponent upsertComponent(Optional<RegenerationComponent> maybeComponent, float magnitude,
-                                                    long duration) {
+    protected RegenerationComponent upsertComponent(Optional<RegenerationComponent> maybeComponent,
+                                                    final EffectContext context) {
         RegenerationComponent component = maybeComponent.orElse(new RegenerationComponent());
-        component.regenerationAmount = TeraMath.floorToInt(magnitude);
+        component.regenerationAmount = TeraMath.floorToInt(context.magnitude);
         component.lastRegenerationTime = time.getGameTimeInMs();
         return component;
     }
 
     @Override
-    protected RegenerationComponent updateComponent(OnEffectModifyEvent event, RegenerationComponent component) {
+    protected RegenerationComponent updateComponent(OnEffectModifyEvent event, RegenerationComponent component,
+                                                    final EffectContext context) {
         component.regenerationAmount = (int) event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
@@ -15,122 +15,64 @@
  */
 package org.terasology.alterationEffects.regenerate;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.health.event.ActivateRegenEvent;
 import org.terasology.math.TeraMath;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the health regeneration effect, which heals an entity for the given magnitude per
  * second for a specified duration.
  */
-public class RegenerationAlterationEffect implements AlterationEffect {
+public class RegenerationAlterationEffect extends ComponentBasedAlterationEffect<RegenerationComponent> {
 
     private final Time time;
-    private final DelayManager delayManager;
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the current time and DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public RegenerationAlterationEffect(Context context) {
+        super(context, RegenerationComponent.class, AlterationEffects.REGENERATION);
         this.time = context.get(Time.class);
-        this.delayManager = context.get(DelayManager.class);
     }
 
-    /**
-     * This will apply the regeneration effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own regeneration effect related modifiers.
-     *
-     * @param instigator    The entity who applied the regen effect.
-     * @param entity        The entity that the regen effect is being applied on.
-     * @param magnitude     The magnitude of the regen effect.
-     * @param duration      The duration of the regen effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a regeneration component attached. If so, just replace the amount
-        // and last regen time, and then save the component. Otherwise, create a new one and attach it to the entity.
-        RegenerationComponent regeneration = entity.getComponent(RegenerationComponent.class);
-        if (regeneration == null) {
-            regeneration = new RegenerationComponent();
-            regeneration.regenerationAmount = TeraMath.floorToInt(magnitude);
-            regeneration.lastRegenerationTime = time.getGameTimeInMs();
-            entity.addComponent(regeneration);
-        } else {
-            regeneration.regenerationAmount = TeraMath.floorToInt(magnitude);
-            regeneration.lastRegenerationTime = time.getGameTimeInMs();
-            entity.saveComponent(regeneration);
-        }
+    protected RegenerationComponent upsertComponent(Optional<RegenerationComponent> maybeComponent, float magnitude,
+                                                    long duration) {
+        RegenerationComponent component = maybeComponent.orElse(new RegenerationComponent());
+        component.regenerationAmount = TeraMath.floorToInt(magnitude);
+        component.lastRegenerationTime = time.getGameTimeInMs();
+        return component;
+    }
 
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // regeneration effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;      // This will keep track of the current modified duration.
-        boolean modifiersFound = false; // This flag will keep track if there were any modifiers collected in the event.
-
-        // If the effect modify event is consumed, don't apply this health regeneration effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                regeneration.regenerationAmount = (int) modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // Save the component so the latest changes to it don't get lost when the game's exited.
-        entity.saveComponent(regeneration);
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE ) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.REGENERATION, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this regeneration effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(RegenerationComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    @Override
+    protected RegenerationComponent updateComponent(OnEffectModifyEvent event, RegenerationComponent component) {
+        component.regenerationAmount = (int) event.getMagnitudeResultValue();
+        return component;
     }
 
     /**
-     * This will apply the regeneration effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
+     * This will apply the regeneration effect on the given entity by calling the method {@link #applyEffect(EntityRef,
+     * EntityRef, float, long)}.
      *
-     * @param instigator    The entity who applied the regen effect.
-     * @param entity        The entity that the regen effect is being applied on.
-     * @param id            Id is used for unique identification in regen scheduler.
-     * @param magnitude     The magnitude of the regen effect.
-     * @param duration      The duration of the regen effect.
+     * @param instigator The entity who applied the regen effect.
+     * @param entity The entity that the regen effect is being applied on.
+     * @param id Id is used for unique identification in regen scheduler.
+     * @param magnitude The magnitude of the regen effect.
+     * @param duration The duration of the regen effect.
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        //TODO: what is happening here? why is this commented? how does it related to the code above?
         //applyEffect(instigator, entity, magnitude, duration);
         if (magnitude != 0) {
             entity.send(new ActivateRegenEvent(id, magnitude, ((float) duration) / 1000));

--- a/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/regenerate/RegenerationAlterationEffect.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.regenerate;
 
 import org.terasology.alterationEffects.AlterationEffects;
@@ -74,9 +61,17 @@ public class RegenerationAlterationEffect extends ComponentBasedAlterationEffect
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        //TODO: what is happening here? why is this commented? how does it related to the code above?
+        //TODO: this is supposed to be the "new" implementation with the approach above being deprecated
         //applyEffect(instigator, entity, magnitude, duration);
         if (magnitude != 0) {
+            //FIXME(skaldarnar): We blindly set the "end time" of the regen effect to "duration" - that looks wrong.
+            //                   On a deeper look into RegenAuthoritySystem the "end time" is interpreted as
+            //                   duration, though.
+            //FIXME(skaldarnar): "duration" may be -1 to indicated DURATION_INDEFINITE - how does that translate to the
+            //                   regen event we are sending here?
+            //                   Actually, -1 has a special meaning for the regen effect, but it is different from the
+            //                   semantic in alteration effects: heal until the entity has restored full health as
+            //                   opposed to heal indefinitely
             entity.send(new ActivateRegenEvent(id, magnitude, ((float) duration) / 1000));
         }
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -39,14 +40,15 @@ public class GlueAlterationEffect extends ComponentBasedAlterationEffect<GlueCom
     }
 
     @Override
-    protected GlueComponent upsertComponent(Optional<GlueComponent> maybeComponent, float magnitude, long duration) {
+    protected GlueComponent upsertComponent(Optional<GlueComponent> maybeComponent, final EffectContext context) {
         GlueComponent glueComponent = maybeComponent.orElse(new GlueComponent());
-        glueComponent.multiplier = magnitude;
+        glueComponent.multiplier = context.magnitude;
         return glueComponent;
     }
 
     @Override
-    protected GlueComponent updateComponent(OnEffectModifyEvent event, GlueComponent component) {
+    protected GlueComponent updateComponent(OnEffectModifyEvent event, GlueComponent component,
+                                            final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
@@ -15,112 +15,39 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
- * This handles the application of the glue effect, which slows down an entity's walk speed (based on the magnitude)
- * and prevents it from jumping for a specified duration.
+ * This handles the application of the glue effect, which slows down an entity's walk speed (based on the magnitude) and
+ * prevents it from jumping for a specified duration.
  */
-public class GlueAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class GlueAlterationEffect extends ComponentBasedAlterationEffect<GlueComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public GlueAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, GlueComponent.class, AlterationEffects.GLUE);
     }
 
-    /**
-     * This will apply the glue effect on the given entity. This method will send out an event to the other applicable
-     * effect systems so that they can contribute with their own glue effect related modifiers.
-     *
-     * @param instigator    The entity who applied the glue effect.
-     * @param entity        The entity that the glue effect is being applied on.
-     * @param magnitude     The magnitude of the glue effect.
-     * @param duration      The duration of the glue effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a glue component attached. If so, just replace the multiplier,
-        // and then save the component. Otherwise, create a new one and attach it to the entity.
-        GlueComponent glue = entity.getComponent(GlueComponent.class);
-        if (glue == null) {
-            glue = new GlueComponent();
-            glue.multiplier = magnitude;
-            entity.addComponent(glue);
-        } else {
-            glue.multiplier = magnitude;
-            entity.saveComponent(glue);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // glue effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this glue effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                glue.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this glue effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(GlueComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected GlueComponent upsertComponent(Optional<GlueComponent> maybeComponent, float magnitude, long duration) {
+        GlueComponent glueComponent = maybeComponent.orElse(new GlueComponent());
+        glueComponent.multiplier = magnitude;
+        return glueComponent;
     }
 
-    /**
-     * This will apply the glue effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the glue effect.
-     * @param entity        The entity that the glue effect is being applied on.
-     * @param id            Inapplicable to the glue effect.
-     * @param magnitude     The magnitude of the glue effect.
-     * @param duration      The duration of the glue effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected GlueComponent updateComponent(OnEffectModifyEvent event, GlueComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
@@ -15,18 +15,19 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the item use speed effect, which speeds up an entity's item use rate (based on the
  * magnitude) for a specified duration.
  */
-public class ItemUseSpeedAlterationEffect implements AlterationEffect {
+public class ItemUseSpeedAlterationEffect extends ComponentBasedAlterationEffect<ItemUseSpeedComponent> {
 
     private DelayManager delayManager;
 
@@ -34,93 +35,23 @@ public class ItemUseSpeedAlterationEffect implements AlterationEffect {
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public ItemUseSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, ItemUseSpeedComponent.class, AlterationEffects.ITEM_USE_SPEED);
     }
 
-    /**
-     * This will apply the item use speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own item use speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the item use speed effect.
-     * @param entity        The entity that the item use speed effect is being applied on.
-     * @param magnitude     The magnitude of the item use speed effect.
-     * @param duration      The duration of the item use speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a item use speed component attached. If so, just replace the
-        // speed multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        ItemUseSpeedComponent itemUseSpeed = entity.getComponent(ItemUseSpeedComponent.class);
-        if (itemUseSpeed == null) {
-            itemUseSpeed = new ItemUseSpeedComponent();
-            itemUseSpeed.multiplier = magnitude;
-            entity.addComponent(itemUseSpeed);
-        } else {
-            itemUseSpeed.multiplier = magnitude;
-            entity.saveComponent(itemUseSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // item use speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this item use speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                itemUseSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this item use speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(ItemUseSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected ItemUseSpeedComponent upsertComponent(Optional<ItemUseSpeedComponent> maybeComponent, float magnitude,
+                                                    long duration) {
+        ItemUseSpeedComponent itemUseSpeed = maybeComponent.orElse(new ItemUseSpeedComponent());
+        itemUseSpeed.multiplier = magnitude;
+        return itemUseSpeed;
     }
 
-    /**
-     * This will apply the item use speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the item use speed effect.
-     * @param entity        The entity that the item use speed effect is being applied on.
-     * @param id            Inapplicable to the item use speed effect.
-     * @param magnitude     The magnitude of the item use speed effect.
-     * @param duration      The duration of the item use speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected ItemUseSpeedComponent updateComponent(OnEffectModifyEvent event, ItemUseSpeedComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 import org.terasology.logic.delay.DelayManager;
@@ -42,15 +43,16 @@ public class ItemUseSpeedAlterationEffect extends ComponentBasedAlterationEffect
     }
 
     @Override
-    protected ItemUseSpeedComponent upsertComponent(Optional<ItemUseSpeedComponent> maybeComponent, float magnitude,
-                                                    long duration) {
+    protected ItemUseSpeedComponent upsertComponent(Optional<ItemUseSpeedComponent> maybeComponent,
+                                                    final EffectContext context) {
         ItemUseSpeedComponent itemUseSpeed = maybeComponent.orElse(new ItemUseSpeedComponent());
-        itemUseSpeed.multiplier = magnitude;
+        itemUseSpeed.multiplier = context.magnitude;
         return itemUseSpeed;
     }
 
     @Override
-    protected ItemUseSpeedComponent updateComponent(OnEffectModifyEvent event, ItemUseSpeedComponent component) {
+    protected ItemUseSpeedComponent updateComponent(OnEffectModifyEvent event, ItemUseSpeedComponent component,
+                                                    final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
@@ -15,114 +15,40 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
-import org.terasology.alterationEffects.regenerate.RegenerationComponent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
-import org.terasology.math.TeraMath;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the jump speed effect, which increases an entity's jump speed and height (based on
  * the magnitude) for a specified duration.
  */
-public class JumpSpeedAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class JumpSpeedAlterationEffect extends ComponentBasedAlterationEffect<JumpSpeedComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public JumpSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, JumpSpeedComponent.class, AlterationEffects.JUMP_SPEED);
     }
 
-    /**
-     * This will apply the jump speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own jump speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the jump speed effect.
-     * @param entity        The entity that the jump speed effect is being applied on.
-     * @param magnitude     The magnitude of the jump speed effect.
-     * @param duration      The duration of the jump speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a jump speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        JumpSpeedComponent jumpSpeed = entity.getComponent(JumpSpeedComponent.class);
-        if (jumpSpeed == null) {
-            jumpSpeed = new JumpSpeedComponent();
-            jumpSpeed.multiplier = magnitude;
-            entity.addComponent(jumpSpeed);
-        } else {
-            jumpSpeed.multiplier = magnitude;
-            entity.saveComponent(jumpSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // jump speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this jump speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                jumpSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this jump speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(JumpSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected JumpSpeedComponent upsertComponent(Optional<JumpSpeedComponent> maybeComponent, float magnitude,
+                                                 long duration) {
+        JumpSpeedComponent jumpSpeed = maybeComponent.orElse(new JumpSpeedComponent());
+        jumpSpeed.multiplier = magnitude;
+        return jumpSpeed;
     }
 
-    /**
-     * This will apply the jump speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the jump speed effect.
-     * @param entity        The entity that the jump speed effect is being applied on.
-     * @param id            Inapplicable to the jump speed effect.
-     * @param magnitude     The magnitude of the jump speed effect.
-     * @param duration      The duration of the jump speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected JumpSpeedComponent updateComponent(OnEffectModifyEvent event, JumpSpeedComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -39,15 +40,16 @@ public class JumpSpeedAlterationEffect extends ComponentBasedAlterationEffect<Ju
     }
 
     @Override
-    protected JumpSpeedComponent upsertComponent(Optional<JumpSpeedComponent> maybeComponent, float magnitude,
-                                                 long duration) {
+    protected JumpSpeedComponent upsertComponent(Optional<JumpSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
         JumpSpeedComponent jumpSpeed = maybeComponent.orElse(new JumpSpeedComponent());
-        jumpSpeed.multiplier = magnitude;
+        jumpSpeed.multiplier = context.magnitude;
         return jumpSpeed;
     }
 
     @Override
-    protected JumpSpeedComponent updateComponent(OnEffectModifyEvent event, JumpSpeedComponent component) {
+    protected JumpSpeedComponent updateComponent(OnEffectModifyEvent event, JumpSpeedComponent component,
+                                                 final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
@@ -15,112 +15,34 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the multi jump effect, which allows an entity to jump multiple times before hitting
  * solid ground for a specified duration.
  */
-public class MultiJumpAlterationEffect implements AlterationEffect {
+public class MultiJumpAlterationEffect extends ComponentBasedAlterationEffect<MultiJumpComponent> {
 
-    private DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public MultiJumpAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, MultiJumpComponent.class, AlterationEffects.MULTI_JUMP);
     }
 
-    /**
-     * This will apply the multi jump effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own multi jump effect related modifiers.
-     *
-     * @param instigator    The entity who applied the multi jump effect.
-     * @param entity        The entity that the multi jump effect is being applied on.
-     * @param magnitude     The magnitude of the multi jump effect.
-     * @param duration      The duration of the multi jump effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a multi jump component attached. If so, just replace the number
-        // of jumps multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        MultiJumpComponent multiJump = entity.getComponent(MultiJumpComponent.class);
-        if (multiJump == null) {
-            multiJump = new MultiJumpComponent();
-            multiJump.multiplier = magnitude;
-            entity.addComponent(multiJump);
-        } else {
-            multiJump.multiplier = magnitude;
-            entity.saveComponent(multiJump);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // multi jump effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this multi jump effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                multiJump.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this multi jump effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(MultiJumpComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected MultiJumpComponent upsertComponent(Optional<MultiJumpComponent> maybeComponent, float magnitude,
+                                                 long duration) {
+        MultiJumpComponent multiJump = maybeComponent.orElse(new MultiJumpComponent());
+        multiJump.multiplier = magnitude;
+        return multiJump;
     }
 
-    /**
-     * This will apply the multi jump effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the multi jump effect.
-     * @param entity        The entity that the multi jump effect is being applied on.
-     * @param id            Inapplicable to the multi jump effect.
-     * @param magnitude     The magnitude of the multi jump effect.
-     * @param duration      The duration of the multi jump effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected MultiJumpComponent updateComponent(OnEffectModifyEvent event, MultiJumpComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -33,15 +34,16 @@ public class MultiJumpAlterationEffect extends ComponentBasedAlterationEffect<Mu
     }
 
     @Override
-    protected MultiJumpComponent upsertComponent(Optional<MultiJumpComponent> maybeComponent, float magnitude,
-                                                 long duration) {
+    protected MultiJumpComponent upsertComponent(Optional<MultiJumpComponent> maybeComponent,
+                                                 final EffectContext context) {
         MultiJumpComponent multiJump = maybeComponent.orElse(new MultiJumpComponent());
-        multiJump.multiplier = magnitude;
+        multiJump.multiplier = context.magnitude;
         return multiJump;
     }
 
     @Override
-    protected MultiJumpComponent updateComponent(OnEffectModifyEvent event, MultiJumpComponent component) {
+    protected MultiJumpComponent updateComponent(OnEffectModifyEvent event, MultiJumpComponent component,
+                                                 final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -32,12 +33,13 @@ public class StunAlterationEffect extends ComponentBasedAlterationEffect<StunCom
     }
 
     @Override
-    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent, float magnitude, long duration) {
+    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent, final EffectContext context) {
         return maybeComponent.orElse(new StunComponent());
     }
 
     @Override
-    protected StunComponent updateComponent(OnEffectModifyEvent event, StunComponent component) {
+    protected StunComponent updateComponent(OnEffectModifyEvent event, StunComponent component,
+                                            final EffectContext context) {
         return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
@@ -15,105 +15,29 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the stun effect, which prevents an entity from walking or jumping for a specified
  * duration.
  */
-public class StunAlterationEffect implements AlterationEffect {
-
-    private final DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
+public class StunAlterationEffect extends ComponentBasedAlterationEffect<StunComponent> {
     public StunAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, StunComponent.class, AlterationEffects.STUN);
     }
 
-    /**
-     * This will apply the stun effect on the given entity. This method will send out an event to the other applicable
-     * effect systems so that they can contribute with their own stun effect related modifiers.
-     *
-     * @param instigator    The entity who applied the stun effect.
-     * @param entity        The entity that the stun effect is being applied on.
-     * @param magnitude     The magnitude of the stun effect.
-     * @param duration      The duration of the stun effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a stun component attached. If not, create a new one and attach it
-        // to the entity.
-        StunComponent stun = entity.getComponent(StunComponent.class);
-        if (stun == null) {
-            stun = new StunComponent();
-            entity.addComponent(stun);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // stun effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this stun effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the shortest duration, and assign them to the modifiedDuration.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this stun effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(StunComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent) {
+        return maybeComponent.orElse(new StunComponent());
     }
 
-    /**
-     * This will apply the stun effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the stun effect.
-     * @param entity        The entity that the stun effect is being applied on.
-     * @param id            Inapplicable to the stun effect.
-     * @param magnitude     The magnitude of the stun effect.
-     * @param duration      The duration of the stun effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected StunComponent updateComponent(OnEffectModifyEvent event, StunComponent component) {
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
@@ -32,7 +32,7 @@ public class StunAlterationEffect extends ComponentBasedAlterationEffect<StunCom
     }
 
     @Override
-    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent) {
+    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent, float magnitude, long duration) {
         return maybeComponent.orElse(new StunComponent());
     }
 

--- a/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -32,13 +33,15 @@ public class SwimSpeedAlterationEffect extends ComponentBasedAlterationEffect<Sw
         super(context, SwimSpeedComponent.class, AlterationEffects.SWIM_SPEED);
     }
 
-    protected SwimSpeedComponent upsertComponent(Optional<SwimSpeedComponent> maybeComponent, float magnitude, long duration) {
+    protected SwimSpeedComponent upsertComponent(Optional<SwimSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
         SwimSpeedComponent swimSpeed = maybeComponent.orElse(new SwimSpeedComponent());
-        swimSpeed.multiplier = magnitude;
+        swimSpeed.multiplier = context.magnitude;
         return swimSpeed;
     }
 
-    protected SwimSpeedComponent updateComponent(OnEffectModifyEvent event, SwimSpeedComponent component) {
+    protected SwimSpeedComponent updateComponent(OnEffectModifyEvent event, SwimSpeedComponent component,
+                                                 final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }

--- a/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
@@ -15,112 +15,31 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the jump speed effect, which increases an entity's swim speed (based on the
  * magnitude) for a specified duration.
  */
-public class SwimSpeedAlterationEffect implements AlterationEffect {
+public class SwimSpeedAlterationEffect extends ComponentBasedAlterationEffect<SwimSpeedComponent> {
 
-    private final DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public SwimSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, SwimSpeedComponent.class, AlterationEffects.SWIM_SPEED);
     }
 
-    /**
-     * This will apply the swim speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own swim speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the swim speed effect.
-     * @param entity        The entity that the swim speed effect is being applied on.
-     * @param magnitude     The magnitude of the swim speed effect.
-     * @param duration      The duration of the swim speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a swim speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        SwimSpeedComponent swimSpeed = entity.getComponent(SwimSpeedComponent.class);
-        if (swimSpeed == null) {
-            swimSpeed = new SwimSpeedComponent();
-            swimSpeed.multiplier = magnitude;
-            entity.addComponent(swimSpeed);
-        } else {
-            swimSpeed.multiplier = magnitude;
-            entity.saveComponent(swimSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // swim speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this swim speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                swimSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this swim speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(SwimSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected SwimSpeedComponent upsertComponent(Optional<SwimSpeedComponent> maybeComponent, float magnitude, long duration) {
+        SwimSpeedComponent swimSpeed = maybeComponent.orElse(new SwimSpeedComponent());
+        swimSpeed.multiplier = magnitude;
+        return swimSpeed;
     }
 
-    /**
-     * This will apply the swim speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the swim speed effect.
-     * @param entity        The entity that the swim speed effect is being applied on.
-     * @param id            Inapplicable to the swim speed effect.
-     * @param magnitude     The magnitude of the swim speed effect.
-     * @param duration      The duration of the swim speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected SwimSpeedComponent updateComponent(OnEffectModifyEvent event, SwimSpeedComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
@@ -15,112 +15,32 @@
  */
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the walk speed effect, which increases an entity's walk speed (based on the
  * magnitude) for a specified duration.
  */
-public class WalkSpeedAlterationEffect implements AlterationEffect {
+public class WalkSpeedAlterationEffect extends ComponentBasedAlterationEffect<WalkSpeedComponent> {
 
-    private DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public WalkSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, WalkSpeedComponent.class, AlterationEffects.WALK_SPEED);
     }
 
-    /**
-     * This will apply the walk speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own walk speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the walk speed effect.
-     * @param entity        The entity that the walk speed effect is being applied on.
-     * @param magnitude     The magnitude of the walk speed effect.
-     * @param duration      The duration of the walk speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a swim speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        WalkSpeedComponent walkSpeed = entity.getComponent(WalkSpeedComponent.class);
-        if (walkSpeed == null) {
-            walkSpeed = new WalkSpeedComponent();
-            walkSpeed.multiplier = magnitude;
-            entity.addComponent(walkSpeed);
-        } else {
-            walkSpeed.multiplier = magnitude;
-            entity.saveComponent(walkSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // walk speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this walk speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                walkSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this walk speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(WalkSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected WalkSpeedComponent upsertComponent(Optional<WalkSpeedComponent> maybeComponent, float magnitude,
+                                                 long duration) {
+        WalkSpeedComponent walkSpeed = maybeComponent.orElse(new WalkSpeedComponent());
+        walkSpeed.multiplier = magnitude;
+        return walkSpeed;
     }
 
-    /**
-     * This will apply the walk speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the walk speed effect.
-     * @param entity        The entity that the walk speed effect is being applied on.
-     * @param id            Inapplicable to the walk speed effect.
-     * @param magnitude     The magnitude of the walk speed effect.
-     * @param duration      The duration of the walk speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected WalkSpeedComponent updateComponent(OnEffectModifyEvent event, WalkSpeedComponent component) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
@@ -17,6 +17,7 @@ package org.terasology.alterationEffects.speed;
 
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
 
@@ -32,14 +33,15 @@ public class WalkSpeedAlterationEffect extends ComponentBasedAlterationEffect<Wa
         super(context, WalkSpeedComponent.class, AlterationEffects.WALK_SPEED);
     }
 
-    protected WalkSpeedComponent upsertComponent(Optional<WalkSpeedComponent> maybeComponent, float magnitude,
-                                                 long duration) {
+    protected WalkSpeedComponent upsertComponent(Optional<WalkSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
         WalkSpeedComponent walkSpeed = maybeComponent.orElse(new WalkSpeedComponent());
-        walkSpeed.multiplier = magnitude;
+        walkSpeed.multiplier = context.magnitude;
         return walkSpeed;
     }
 
-    protected WalkSpeedComponent updateComponent(OnEffectModifyEvent event, WalkSpeedComponent component) {
+    protected WalkSpeedComponent updateComponent(OnEffectModifyEvent event, WalkSpeedComponent component,
+                                                 final EffectContext context) {
         component.multiplier = event.getMagnitudeResultValue();
         return component;
     }


### PR DESCRIPTION
This is a common base class for alteration effects based on a single component. It only requires implementations of component _upsert_ and _updated_ to fully define an effect (in addition to the component class and the general effect id).

The implementation is extracted from `WalkSpeedAlterationEffect` and can be found in other effect classes such as `SwimSpeedAlterationEffect` or `StunEffect`.

I hope that this will help to a) understand the individual effects and spot similarities and differences between them, and b) help to focus on the implementation of component-based alteration effects itself (without being distracted by details about a specific effect in particular).

---

We can merge this in smaller chunks for easier (and hopefully more careful) review:

- feat: Introduce a ComponentBasedAlterationEffect 
- feat: Use component-based effect for package 'speed'
- feat: Use component-based effect for package 'regenerate'
- ...