### PR TITLE
feat: Use component-based effect for 'speed' effects

### DIFF
--- a/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
@@ -180,7 +180,6 @@ public abstract class ComponentBasedAlterationEffect<C extends Component> implem
                     modifiedDuration);
         } else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
             // no modifiers but positive duration and definite (and not consumed)
-          
             // add a delayed action to the DelayManager using the old system.
             delayManager.addDelayedAction(entity,
                     AlterationEffects.EXPIRE_TRIGGER_PREFIX + effectId, duration);

--- a/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/ComponentBasedAlterationEffect.java
@@ -1,0 +1,87 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.alterationEffects;
+
+import org.terasology.context.Context;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
+
+public abstract class ComponentBasedAlterationEffect<C extends Component> implements AlterationEffect {
+
+    private final DelayManager delayManager;
+    protected final Class<C> componentClass;
+    private final String effectId;
+
+    public ComponentBasedAlterationEffect(Context context, Class<C> componentClass, String effectIdentifier) {
+        this.delayManager = context.get(DelayManager.class);
+        this.componentClass = componentClass;
+        this.effectId = effectIdentifier;
+    }
+
+    protected abstract C upsertComponent(Optional<C> maybeComponent, final EffectContext context);
+
+    protected abstract C updateComponent(OnEffectModifyEvent event, C component, final EffectContext context);
+
+    protected void removeComponent(final EffectContext context) {
+        context.entity.removeComponent(componentClass);
+    }
+
+    @Override
+    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
+        applyEffect(instigator, entity, "", magnitude, duration);
+    }
+
+    @Override
+    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        final EffectContext context = new EffectContext(instigator, entity, id, magnitude, duration);
+        //TODO: who should be responsible for setting base magnitude and duration?
+        //      can we just pass it with OnEffectModifyEvent?
+        entity.upsertComponent(componentClass, maybeComponent -> upsertComponent(maybeComponent, context));
+
+        // 2. send OnEffectModifyEvent
+        OnEffectModifyEvent effectModifyEvent = entity.send(
+                new OnEffectModifyEvent(instigator, entity, 0, 0, this, id)
+        );
+
+        long modifiedDuration = 0;
+        boolean modifiersFound = false;
+
+        // If the effect modify event is consumed, don't apply this walk speed effect.meute
+        if (!effectModifyEvent.isConsumed()) {
+            modifiedDuration = effectModifyEvent.getShortestDuration();
+
+            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
+                entity.updateComponent(componentClass, c -> updateComponent(effectModifyEvent, c, context));
+                modifiersFound = true;
+            }
+        }
+
+        // 3. update component from OnEffectModifyEvent
+        //      (OnEffectModifyEvent, C) -> C
+        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
+
+            String effectIDWithShortestDuration = effectModifyEvent.getEffectIDWithShortestDuration();
+            delayManager.addDelayedAction(entity,
+                    AlterationEffects.EXPIRE_TRIGGER_PREFIX + effectId + "|" + effectIDWithShortestDuration,
+                    modifiedDuration);
+        } else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
+            // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify
+            // event was not consumed,
+            // add a delayed action to the DelayManager using the old system.
+            delayManager.addDelayedAction(entity,
+                    AlterationEffects.EXPIRE_TRIGGER_PREFIX + effectId, duration);
+        } else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
+            // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event
+            // have infinite
+            // duration, remove the component associated with this walk speed effect.
+            removeComponent(context);
+        }
+        // If this point is reached and none of the above if-clauses were met, that means there was at least one
+        // modifier
+        // collected in the event which has infinite duration.
+    }
+}

--- a/src/main/java/org/terasology/alterationEffects/EffectContext.java
+++ b/src/main/java/org/terasology/alterationEffects/EffectContext.java
@@ -1,0 +1,25 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.alterationEffects;
+
+import org.terasology.entitySystem.entity.EntityRef;
+
+/**
+ * Immutable context for implementing alteration effects.
+ */
+public class EffectContext {
+    public final EntityRef instigator;
+    public final EntityRef entity;
+    public final String id;
+    public final float magnitude;
+    public final long duration;
+
+    public EffectContext(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        this.instigator = instigator;
+        this.entity = entity;
+        this.id = id;
+        this.magnitude = magnitude;
+        this.duration = duration;
+    }
+}

--- a/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/GlueAlterationEffect.java
@@ -1,126 +1,42 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
- * This handles the application of the glue effect, which slows down an entity's walk speed (based on the magnitude)
- * and prevents it from jumping for a specified duration.
+ * This handles the application of the glue effect, which slows down an entity's walk speed (based on the magnitude) and
+ * prevents it from jumping for a specified duration.
  */
-public class GlueAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class GlueAlterationEffect extends ComponentBasedAlterationEffect<GlueComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public GlueAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, GlueComponent.class, AlterationEffects.GLUE);
     }
 
-    /**
-     * This will apply the glue effect on the given entity. This method will send out an event to the other applicable
-     * effect systems so that they can contribute with their own glue effect related modifiers.
-     *
-     * @param instigator    The entity who applied the glue effect.
-     * @param entity        The entity that the glue effect is being applied on.
-     * @param magnitude     The magnitude of the glue effect.
-     * @param duration      The duration of the glue effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a glue component attached. If so, just replace the multiplier,
-        // and then save the component. Otherwise, create a new one and attach it to the entity.
-        GlueComponent glue = entity.getComponent(GlueComponent.class);
-        if (glue == null) {
-            glue = new GlueComponent();
-            glue.multiplier = magnitude;
-            entity.addComponent(glue);
-        } else {
-            glue.multiplier = magnitude;
-            entity.saveComponent(glue);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // glue effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this glue effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                glue.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.GLUE, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this glue effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(GlueComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected GlueComponent upsertComponent(Optional<GlueComponent> maybeComponent, final EffectContext context) {
+        GlueComponent glueComponent = maybeComponent.orElse(new GlueComponent());
+        glueComponent.multiplier = context.magnitude;
+        return glueComponent;
     }
 
-    /**
-     * This will apply the glue effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the glue effect.
-     * @param entity        The entity that the glue effect is being applied on.
-     * @param id            Inapplicable to the glue effect.
-     * @param magnitude     The magnitude of the glue effect.
-     * @param duration      The duration of the glue effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected GlueComponent updateComponent(OnEffectModifyEvent event, GlueComponent component,
+                                            final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/ItemUseSpeedAlterationEffect.java
@@ -1,32 +1,21 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the item use speed effect, which speeds up an entity's item use rate (based on the
  * magnitude) for a specified duration.
  */
-public class ItemUseSpeedAlterationEffect implements AlterationEffect {
+public class ItemUseSpeedAlterationEffect extends ComponentBasedAlterationEffect<ItemUseSpeedComponent> {
 
     private DelayManager delayManager;
 
@@ -34,93 +23,24 @@ public class ItemUseSpeedAlterationEffect implements AlterationEffect {
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public ItemUseSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, ItemUseSpeedComponent.class, AlterationEffects.ITEM_USE_SPEED);
     }
 
-    /**
-     * This will apply the item use speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own item use speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the item use speed effect.
-     * @param entity        The entity that the item use speed effect is being applied on.
-     * @param magnitude     The magnitude of the item use speed effect.
-     * @param duration      The duration of the item use speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a item use speed component attached. If so, just replace the
-        // speed multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        ItemUseSpeedComponent itemUseSpeed = entity.getComponent(ItemUseSpeedComponent.class);
-        if (itemUseSpeed == null) {
-            itemUseSpeed = new ItemUseSpeedComponent();
-            itemUseSpeed.multiplier = magnitude;
-            entity.addComponent(itemUseSpeed);
-        } else {
-            itemUseSpeed.multiplier = magnitude;
-            entity.saveComponent(itemUseSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // item use speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this item use speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                itemUseSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.ITEM_USE_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this item use speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(ItemUseSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected ItemUseSpeedComponent upsertComponent(Optional<ItemUseSpeedComponent> maybeComponent,
+                                                    final EffectContext context) {
+        ItemUseSpeedComponent itemUseSpeed = maybeComponent.orElse(new ItemUseSpeedComponent());
+        itemUseSpeed.multiplier = context.magnitude;
+        return itemUseSpeed;
     }
 
-    /**
-     * This will apply the item use speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the item use speed effect.
-     * @param entity        The entity that the item use speed effect is being applied on.
-     * @param id            Inapplicable to the item use speed effect.
-     * @param magnitude     The magnitude of the item use speed effect.
-     * @param duration      The duration of the item use speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected ItemUseSpeedComponent updateComponent(OnEffectModifyEvent event, ItemUseSpeedComponent component,
+                                                    final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/JumpSpeedAlterationEffect.java
@@ -1,128 +1,43 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
-import org.terasology.alterationEffects.regenerate.RegenerationComponent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
-import org.terasology.math.TeraMath;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the jump speed effect, which increases an entity's jump speed and height (based on
  * the magnitude) for a specified duration.
  */
-public class JumpSpeedAlterationEffect implements AlterationEffect {
-
-    private DelayManager delayManager;
+public class JumpSpeedAlterationEffect extends ComponentBasedAlterationEffect<JumpSpeedComponent> {
 
     /**
      * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
      * used to get the DelayManager.
      *
-     * @param context       The context which this effect will be executed on.
+     * @param context The context which this effect will be executed on.
      */
     public JumpSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, JumpSpeedComponent.class, AlterationEffects.JUMP_SPEED);
     }
 
-    /**
-     * This will apply the jump speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own jump speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the jump speed effect.
-     * @param entity        The entity that the jump speed effect is being applied on.
-     * @param magnitude     The magnitude of the jump speed effect.
-     * @param duration      The duration of the jump speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a jump speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        JumpSpeedComponent jumpSpeed = entity.getComponent(JumpSpeedComponent.class);
-        if (jumpSpeed == null) {
-            jumpSpeed = new JumpSpeedComponent();
-            jumpSpeed.multiplier = magnitude;
-            entity.addComponent(jumpSpeed);
-        } else {
-            jumpSpeed.multiplier = magnitude;
-            entity.saveComponent(jumpSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // jump speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this jump speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                jumpSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.JUMP_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this jump speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(JumpSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected JumpSpeedComponent upsertComponent(Optional<JumpSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
+        JumpSpeedComponent jumpSpeed = maybeComponent.orElse(new JumpSpeedComponent());
+        jumpSpeed.multiplier = context.magnitude;
+        return jumpSpeed;
     }
 
-    /**
-     * This will apply the jump speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the jump speed effect.
-     * @param entity        The entity that the jump speed effect is being applied on.
-     * @param id            Inapplicable to the jump speed effect.
-     * @param magnitude     The magnitude of the jump speed effect.
-     * @param duration      The duration of the jump speed effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected JumpSpeedComponent updateComponent(OnEffectModifyEvent event, JumpSpeedComponent component,
+                                                 final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/MultiJumpAlterationEffect.java
@@ -1,126 +1,37 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the multi jump effect, which allows an entity to jump multiple times before hitting
  * solid ground for a specified duration.
  */
-public class MultiJumpAlterationEffect implements AlterationEffect {
+public class MultiJumpAlterationEffect extends ComponentBasedAlterationEffect<MultiJumpComponent> {
 
-    private DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public MultiJumpAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, MultiJumpComponent.class, AlterationEffects.MULTI_JUMP);
     }
 
-    /**
-     * This will apply the multi jump effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own multi jump effect related modifiers.
-     *
-     * @param instigator    The entity who applied the multi jump effect.
-     * @param entity        The entity that the multi jump effect is being applied on.
-     * @param magnitude     The magnitude of the multi jump effect.
-     * @param duration      The duration of the multi jump effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a multi jump component attached. If so, just replace the number
-        // of jumps multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        MultiJumpComponent multiJump = entity.getComponent(MultiJumpComponent.class);
-        if (multiJump == null) {
-            multiJump = new MultiJumpComponent();
-            multiJump.multiplier = magnitude;
-            entity.addComponent(multiJump);
-        } else {
-            multiJump.multiplier = magnitude;
-            entity.saveComponent(multiJump);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // multi jump effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this multi jump effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                multiJump.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.MULTI_JUMP, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this multi jump effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(MultiJumpComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected MultiJumpComponent upsertComponent(Optional<MultiJumpComponent> maybeComponent,
+                                                 final EffectContext context) {
+        MultiJumpComponent multiJump = maybeComponent.orElse(new MultiJumpComponent());
+        multiJump.multiplier = context.magnitude;
+        return multiJump;
     }
 
-    /**
-     * This will apply the multi jump effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the multi jump effect.
-     * @param entity        The entity that the multi jump effect is being applied on.
-     * @param id            Inapplicable to the multi jump effect.
-     * @param magnitude     The magnitude of the multi jump effect.
-     * @param duration      The duration of the multi jump effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected MultiJumpComponent updateComponent(OnEffectModifyEvent event, MultiJumpComponent component,
+                                                 final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/StunAlterationEffect.java
@@ -1,119 +1,32 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the stun effect, which prevents an entity from walking or jumping for a specified
  * duration.
  */
-public class StunAlterationEffect implements AlterationEffect {
-
-    private final DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
+public class StunAlterationEffect extends ComponentBasedAlterationEffect<StunComponent> {
     public StunAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, StunComponent.class, AlterationEffects.STUN);
     }
 
-    /**
-     * This will apply the stun effect on the given entity. This method will send out an event to the other applicable
-     * effect systems so that they can contribute with their own stun effect related modifiers.
-     *
-     * @param instigator    The entity who applied the stun effect.
-     * @param entity        The entity that the stun effect is being applied on.
-     * @param magnitude     The magnitude of the stun effect.
-     * @param duration      The duration of the stun effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a stun component attached. If not, create a new one and attach it
-        // to the entity.
-        StunComponent stun = entity.getComponent(StunComponent.class);
-        if (stun == null) {
-            stun = new StunComponent();
-            entity.addComponent(stun);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // stun effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this stun effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the shortest duration, and assign them to the modifiedDuration.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.STUN, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this stun effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(StunComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected StunComponent upsertComponent(Optional<StunComponent> maybeComponent, final EffectContext context) {
+        return maybeComponent.orElse(new StunComponent());
     }
 
-    /**
-     * This will apply the stun effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the stun effect.
-     * @param entity        The entity that the stun effect is being applied on.
-     * @param id            Inapplicable to the stun effect.
-     * @param magnitude     The magnitude of the stun effect.
-     * @param duration      The duration of the stun effect.
-     */
     @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected StunComponent updateComponent(OnEffectModifyEvent event, StunComponent component,
+                                            final EffectContext context) {
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/SwimSpeedAlterationEffect.java
@@ -1,126 +1,35 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the jump speed effect, which increases an entity's swim speed (based on the
  * magnitude) for a specified duration.
  */
-public class SwimSpeedAlterationEffect implements AlterationEffect {
+public class SwimSpeedAlterationEffect extends ComponentBasedAlterationEffect<SwimSpeedComponent> {
 
-    private final DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public SwimSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, SwimSpeedComponent.class, AlterationEffects.SWIM_SPEED);
     }
 
-    /**
-     * This will apply the swim speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own swim speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the swim speed effect.
-     * @param entity        The entity that the swim speed effect is being applied on.
-     * @param magnitude     The magnitude of the swim speed effect.
-     * @param duration      The duration of the swim speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a swim speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        SwimSpeedComponent swimSpeed = entity.getComponent(SwimSpeedComponent.class);
-        if (swimSpeed == null) {
-            swimSpeed = new SwimSpeedComponent();
-            swimSpeed.multiplier = magnitude;
-            entity.addComponent(swimSpeed);
-        } else {
-            swimSpeed.multiplier = magnitude;
-            entity.saveComponent(swimSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // swim speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this swim speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                swimSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.SWIM_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this swim speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(SwimSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected SwimSpeedComponent upsertComponent(Optional<SwimSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
+        SwimSpeedComponent swimSpeed = maybeComponent.orElse(new SwimSpeedComponent());
+        swimSpeed.multiplier = context.magnitude;
+        return swimSpeed;
     }
 
-    /**
-     * This will apply the swim speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the swim speed effect.
-     * @param entity        The entity that the swim speed effect is being applied on.
-     * @param id            Inapplicable to the swim speed effect.
-     * @param magnitude     The magnitude of the swim speed effect.
-     * @param duration      The duration of the swim speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected SwimSpeedComponent updateComponent(OnEffectModifyEvent event, SwimSpeedComponent component,
+                                                 final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }

--- a/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
+++ b/src/main/java/org/terasology/alterationEffects/speed/WalkSpeedAlterationEffect.java
@@ -1,126 +1,35 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.alterationEffects.speed;
 
-import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
+import org.terasology.alterationEffects.ComponentBasedAlterationEffect;
+import org.terasology.alterationEffects.EffectContext;
 import org.terasology.alterationEffects.OnEffectModifyEvent;
 import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.delay.DelayManager;
+
+import java.util.Optional;
 
 /**
  * This handles the application of the walk speed effect, which increases an entity's walk speed (based on the
  * magnitude) for a specified duration.
  */
-public class WalkSpeedAlterationEffect implements AlterationEffect {
+public class WalkSpeedAlterationEffect extends ComponentBasedAlterationEffect<WalkSpeedComponent> {
 
-    private DelayManager delayManager;
-
-    /**
-     * Constructor. Instantiate an instance of this alteration effect using the provided context. This context will be
-     * used to get the DelayManager.
-     *
-     * @param context       The context which this effect will be executed on.
-     */
     public WalkSpeedAlterationEffect(Context context) {
-        this.delayManager = context.get(DelayManager.class);
+        super(context, WalkSpeedComponent.class, AlterationEffects.WALK_SPEED);
     }
 
-    /**
-     * This will apply the walk speed effect on the given entity. This method will send out an event to the other
-     * applicable effect systems so that they can contribute with their own walk speed effect related modifiers.
-     *
-     * @param instigator    The entity who applied the walk speed effect.
-     * @param entity        The entity that the walk speed effect is being applied on.
-     * @param magnitude     The magnitude of the walk speed effect.
-     * @param duration      The duration of the walk speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        // First, determine if the entity already has a swim speed component attached. If so, just replace the speed
-        // multiplier, and then save the component. Otherwise, create a new one and attach it to the entity.
-        WalkSpeedComponent walkSpeed = entity.getComponent(WalkSpeedComponent.class);
-        if (walkSpeed == null) {
-            walkSpeed = new WalkSpeedComponent();
-            walkSpeed.multiplier = magnitude;
-            entity.addComponent(walkSpeed);
-        } else {
-            walkSpeed.multiplier = magnitude;
-            entity.saveComponent(walkSpeed);
-        }
-
-        // Send out this event to collect all the duration and magnitude modifiers and multipliers that can affect this
-        // walk speed effect.
-        OnEffectModifyEvent effectModifyEvent = entity.send(new OnEffectModifyEvent(instigator, entity, 0, 0, this, ""));
-        long modifiedDuration = 0;
-        boolean modifiersFound = false;
-
-        // If the effect modify event is consumed, don't apply this walk speed effect.
-        if (!effectModifyEvent.isConsumed()) {
-            /*
-            Get the magnitude result value and the shortest duration, and assign them to the modifiedMagnitude and
-            modifiedDuration respectively.
-
-            The shortest duration is used as the effect modifier associated with that will expire in the shortest
-            amount of time, meaning that this effect's total magnitude and next remaining duration will have to be
-            recalculated.
-            */
-            float modifiedMagnitude = effectModifyEvent.getMagnitudeResultValue();
-            modifiedDuration = effectModifyEvent.getShortestDuration();
-
-            // If there's at least one duration and magnitude modifier, set the effect's magnitude and the modifiersFound flag.
-            if (!effectModifyEvent.getDurationModifiers().isEmpty() && !effectModifyEvent.getMagnitudeModifiers().isEmpty()) {
-                walkSpeed.multiplier = modifiedMagnitude;
-                modifiersFound = true;
-            }
-        }
-
-        // If the modified duration is between the accepted values (0 and Long.MAX_VALUE), and the base duration is not infinite,
-        // add a delayed action to the DelayManager using the new system.
-        if (modifiedDuration < Long.MAX_VALUE && modifiedDuration > 0 && duration != AlterationEffects.DURATION_INDEFINITE) {
-            String effectID = effectModifyEvent.getEffectIDWithShortestDuration();
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED + "|" + effectID, modifiedDuration);
-        }
-        // Otherwise, if the duration is greater than 0, there are no modifiers found, and the effect modify event was not consumed,
-        // add a delayed action to the DelayManager using the old system.
-        else if (duration > 0 && !modifiersFound && !effectModifyEvent.isConsumed()) {
-            delayManager.addDelayedAction(entity, AlterationEffects.EXPIRE_TRIGGER_PREFIX + AlterationEffects.WALK_SPEED, duration);
-        }
-        // Otherwise, if there are either no modifiers found, or none of the modifiers collected in the event have infinite
-        // duration, remove the component associated with this walk speed effect.
-        else if (!modifiersFound || !effectModifyEvent.getHasInfDuration()) {
-            entity.removeComponent(WalkSpeedComponent.class);
-        }
-        // If this point is reached and none of the above if-clauses were met, that means there was at least one modifier
-        // collected in the event which has infinite duration.
+    protected WalkSpeedComponent upsertComponent(Optional<WalkSpeedComponent> maybeComponent,
+                                                 final EffectContext context) {
+        WalkSpeedComponent walkSpeed = maybeComponent.orElse(new WalkSpeedComponent());
+        walkSpeed.multiplier = context.magnitude;
+        return walkSpeed;
     }
 
-    /**
-     * This will apply the walk speed effect on the given entity by calling the method
-     * {@link #applyEffect(EntityRef, EntityRef, float, long)}.
-     *
-     * @param instigator    The entity who applied the walk speed effect.
-     * @param entity        The entity that the walk speed effect is being applied on.
-     * @param id            Inapplicable to the walk speed effect.
-     * @param magnitude     The magnitude of the walk speed effect.
-     * @param duration      The duration of the walk speed effect.
-     */
-    @Override
-    public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        applyEffect(instigator, entity, magnitude, duration);
+    protected WalkSpeedComponent updateComponent(OnEffectModifyEvent event, WalkSpeedComponent component,
+                                                 final EffectContext context) {
+        component.multiplier = event.getMagnitudeResultValue();
+        return component;
     }
 }


### PR DESCRIPTION
Extracted from #14
Based on #15 (change target branch once #15 is merged)

Replace the copy-paste implementation of speed-affecting alteration effects with the common component-based base class.