### PR TITLE
test: Add tests for AlterationEffects

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,8 @@
     "description": "Allows for applying effects to a player (or something else) that alter their base state in some fashion.",
     "dependencies": [
         { "id": "CoreAssets", "minVersion": "2.0.1" },
-        { "id": "Health", "minVersion": "1.0.0" }
+        { "id": "Health", "minVersion": "1.0.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.2", "optional": true }
     ],
     "isServerSideOnly": false,
     "isLibrary": true

--- a/src/main/java/org/terasology/alterationEffects/EffectsAuthoritySystem.java
+++ b/src/main/java/org/terasology/alterationEffects/EffectsAuthoritySystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.alterationEffects;
 
+import com.google.common.base.Preconditions;
 import org.terasology.alterationEffects.boost.HealthBoostAlterationEffect;
 import org.terasology.alterationEffects.boost.HealthBoostComponent;
 import org.terasology.alterationEffects.breath.WaterBreathingAlterationEffect;
@@ -42,9 +43,12 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.registry.In;
+import org.terasology.registry.Share;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,7 +59,8 @@ import java.util.regex.Pattern;
  * the more complex effects that require more than just simply removing the effect component from the entity and
  * informing other systems.
  */
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
+@Share(value = EffectsAuthoritySystem.class)
 public class EffectsAuthoritySystem extends BaseComponentSystem {
     /** This will store the mapping of the effect constants to the effect components. */
     private Map<String, Class<? extends Component>> effectComponents = new HashMap<>();
@@ -142,5 +147,10 @@ public class EffectsAuthoritySystem extends BaseComponentSystem {
                 alterationEffects.get(effectName).applyEffect(entity, entity, 0, 0);
             }
         }
+    }
+
+    public AlterationEffect getEffect(final String effectId) {
+        Preconditions.checkArgument(alterationEffects.containsKey(effectId), "Unknown effect ID.");
+        return alterationEffects.get(effectId);
     }
 }

--- a/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
+++ b/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
@@ -1,0 +1,59 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.alterationEffects.speed;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.terasology.alterationEffects.AlterationEffect;
+import org.terasology.alterationEffects.EffectsAuthoritySystem;
+import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.DelayedActionComponent;
+import org.terasology.logic.delay.DelayedActionTriggeredEvent;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.TestEventReceiver;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.registry.In;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MTEExtension.class)
+@Dependencies({"engine", "AlterationEffects"})
+class StunAlterationEffectTest {
+
+    @In
+    private ModuleTestingHelper helper;
+
+    @In
+    private DelayManager delayManager;
+
+    @In
+    private EffectsAuthoritySystem effectsAuthoritySystem;
+
+    @Test
+    void applyEffect() {
+        Context context = helper.createClient();
+        context.put(DelayManager.class, delayManager);
+        EntityRef player = context.get(LocalPlayer.class).getCharacterEntity();
+        StunAlterationEffect stunEffect = new StunAlterationEffect(context);
+        stunEffect.applyEffect(player, player, 5, 1000);
+
+        Assertions.assertTrue(player.hasComponent(StunComponent.class), "Stun component not found");
+        Assertions.assertTrue(player.hasComponent(DelayedActionComponent.class), "Delayed action component not found");
+        TestEventReceiver receiver = new TestEventReceiver<>(context, DelayedActionTriggeredEvent.class, (event, entity) -> {
+           String actionId = event.getActionId();
+           Assertions.assertEquals("AlterationEffects:Expire:STUN", actionId);
+        });
+
+        Assertions.assertFalse(receiver.getEvents().isEmpty(), "No events received");
+
+        boolean timedOut = helper.runWhile(5000, ()-> true);
+        Assertions.assertTrue(timedOut, "Didn't time out");
+        Assertions.assertFalse(player.hasComponent(StunComponent.class), "Component not removed");
+    }
+}

--- a/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
+++ b/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
@@ -10,10 +10,9 @@ import org.terasology.alterationEffects.AlterationEffect;
 import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.EffectsAuthoritySystem;
 import org.terasology.context.Context;
+import org.terasology.engine.modes.StateIngame;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
-import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionComponent;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.players.LocalPlayer;
@@ -24,8 +23,6 @@ import org.terasology.moduletestingenvironment.TestEventReceiver;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.registry.In;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @ExtendWith(MTEExtension.class)
 @Dependencies({"engine", "AlterationEffects"})
 class StunAlterationEffectTest {
@@ -34,21 +31,25 @@ class StunAlterationEffectTest {
     private ModuleTestingHelper helper;
 
     @In
-    private DelayManager delayManager;
-
-    @In
     private EffectsAuthoritySystem effectsAuthoritySystem;
 
     @Test
     void applyEffect() {
         helper.forceAndWaitForGeneration(new Vector3i());
         Context context = helper.createClient();
-        //context.put(DelayManager.class, delayManager);
-        TestEventReceiver receiveOnActivatedComponent = new TestEventReceiver<>(context, OnActivatedComponent.class, (event, entity) -> {}, DelayedActionComponent.class);
-        TestEventReceiver receiveDelayedActionTriggered = new TestEventReceiver<>(context, DelayedActionTriggeredEvent.class, (event, entity) -> {
-            String actionId = event.getActionId();
-            Assertions.assertEquals("AlterationEffects:Expire:STUN", actionId);
-        });
+        TestEventReceiver<OnActivatedComponent> receiveOnActivatedComponent = new TestEventReceiver<>(context,
+                OnActivatedComponent.class, (event, entity) -> {
+        }, DelayedActionComponent.class);
+        TestEventReceiver<DelayedActionTriggeredEvent> receiveDelayedActionTriggered =
+                new TestEventReceiver<>(context, DelayedActionTriggeredEvent.class, (event, entity) -> {
+                    String actionId = event.getActionId();
+                    Assertions.assertEquals("AlterationEffects:Expire:STUN", actionId);
+                });
+
+        Assertions.assertFalse(
+                helper.runUntil(1000,
+                        () -> helper.getEngines().stream().allMatch(engine -> engine.getState().getClass().equals(StateIngame.class))),
+                "Engine(s) not in state 'Ingame'!");
 
         EntityRef player = context.get(LocalPlayer.class).getCharacterEntity();
         AlterationEffect stunEffect = effectsAuthoritySystem.getEffect(AlterationEffects.STUN);
@@ -56,10 +57,11 @@ class StunAlterationEffectTest {
 
         Assertions.assertTrue(player.hasComponent(StunComponent.class), "Stun component not found");
         Assertions.assertTrue(player.hasComponent(DelayedActionComponent.class), "Delayed action component not found");
-        Assertions.assertFalse(receiveOnActivatedComponent.getEvents().isEmpty(), "Delayed action component not activated");
+        Assertions.assertFalse(receiveOnActivatedComponent.getEvents().isEmpty(), "Delayed action component not " +
+                "activated");
         Assertions.assertFalse(receiveDelayedActionTriggered.getEvents().isEmpty(), "No events received");
 
-        boolean timedOut = helper.runWhile(5000, ()-> true);
+        boolean timedOut = helper.runWhile(5000, () -> true);
         Assertions.assertTrue(timedOut, "Didn't time out");
         Assertions.assertFalse(player.hasComponent(StunComponent.class), "Component not removed");
     }

--- a/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
+++ b/src/test/java/org/terasology/alterationEffects/speed/StunAlterationEffectTest.java
@@ -7,13 +7,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.alterationEffects.AlterationEffect;
+import org.terasology.alterationEffects.AlterationEffects;
 import org.terasology.alterationEffects.EffectsAuthoritySystem;
 import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionComponent;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.moduletestingenvironment.MTEExtension;
 import org.terasology.moduletestingenvironment.ModuleTestingHelper;
 import org.terasology.moduletestingenvironment.TestEventReceiver;
@@ -37,20 +41,23 @@ class StunAlterationEffectTest {
 
     @Test
     void applyEffect() {
+        helper.forceAndWaitForGeneration(new Vector3i());
         Context context = helper.createClient();
-        context.put(DelayManager.class, delayManager);
+        //context.put(DelayManager.class, delayManager);
+        TestEventReceiver receiveOnActivatedComponent = new TestEventReceiver<>(context, OnActivatedComponent.class, (event, entity) -> {}, DelayedActionComponent.class);
+        TestEventReceiver receiveDelayedActionTriggered = new TestEventReceiver<>(context, DelayedActionTriggeredEvent.class, (event, entity) -> {
+            String actionId = event.getActionId();
+            Assertions.assertEquals("AlterationEffects:Expire:STUN", actionId);
+        });
+
         EntityRef player = context.get(LocalPlayer.class).getCharacterEntity();
-        StunAlterationEffect stunEffect = new StunAlterationEffect(context);
+        AlterationEffect stunEffect = effectsAuthoritySystem.getEffect(AlterationEffects.STUN);
         stunEffect.applyEffect(player, player, 5, 1000);
 
         Assertions.assertTrue(player.hasComponent(StunComponent.class), "Stun component not found");
         Assertions.assertTrue(player.hasComponent(DelayedActionComponent.class), "Delayed action component not found");
-        TestEventReceiver receiver = new TestEventReceiver<>(context, DelayedActionTriggeredEvent.class, (event, entity) -> {
-           String actionId = event.getActionId();
-           Assertions.assertEquals("AlterationEffects:Expire:STUN", actionId);
-        });
-
-        Assertions.assertFalse(receiver.getEvents().isEmpty(), "No events received");
+        Assertions.assertFalse(receiveOnActivatedComponent.getEvents().isEmpty(), "Delayed action component not activated");
+        Assertions.assertFalse(receiveDelayedActionTriggered.getEvents().isEmpty(), "No events received");
 
         boolean timedOut = helper.runWhile(5000, ()-> true);
         Assertions.assertTrue(timedOut, "Didn't time out");


### PR DESCRIPTION
Currently it's not possible to write reasonable tests for `AlterationEffects`.
The reason for this is that the `DelayManager` doesn't work properly.
More precisely, the `DelayedActionTriggered` seems to never be sent.
See https://github.com/Terasology/ModuleTestingEnvironment/pull/20.
Until this works, this PR is **on hold**.

Fixing the current test failures requires merging https://github.com/Terasology/ModuleTestingEnvironment/pull/19.